### PR TITLE
docs: add changelog section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Ejemplo mínimo de contrato inteligente desplegado y **verificado** en **Celo ma
 
 ## Licencia
 MIT — ver archivo [`LICENSE`](./LICENSE).
+
+## Changelog
+- v0.1.0: initial release (verified on Celo mainnet).


### PR DESCRIPTION
- Added a simple Changelog section to README.
- Context: Celo mainnet verified contract with link to Blockscout.
